### PR TITLE
Move the EPCC client ID and secret validation to provider.go

### DIFF
--- a/external/sdk/epcc/config.go
+++ b/external/sdk/epcc/config.go
@@ -32,12 +32,6 @@ func init() {
 		log.Fatal(err.Error())
 	}
 
-	if cfg.Credentials.ClientID == "" {
-		log.Fatal("Required environment variable EPCC_CLIENT_ID not found")
-	}
-	if cfg.Credentials.ClientSecret == "" {
-		log.Fatal("Required environment variable EPCC_CLIENT_SECRET not found")
-	}
 }
 
 // Config is used to keep track of configuration in one place.

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -75,28 +75,28 @@ func New(version string) func() *schema.Provider {
 				},
 			},
 			DataSourcesMap: map[string]*schema.Resource{
-				"epcc_account":                         dataSourceEpccAccount(),
-				"epcc_catalog":                         dataSourceEpccCatalog(),
-				"epcc_currency":                        dataSourceEpccCurrency(),
-				"epcc_customer":                        dataSourceEpccCustomer(),
-				"epcc_entry":                           dataSourceEpccEntry(),
-				"epcc_field":                           dataSourceEpccField(),
-				"epcc_file":                            dataSourceEpccFile(),
-				"epcc_flow":                            dataSourceEpccFlow(),
-				"epcc_hierarchy":                       dataSourceEpccHierarchy(),
-				"epcc_integration":                     IntegrationDataSourceProvider{}.DataSource(),
-				"epcc_node":                            dataSourceEpccNode(),
-				"epcc_node_product":                    dataSourceEpccNodeProduct(),
-				"epcc_payment_gateway":                 PaymentGatewayDataSourceProvider{}.DataSource(),
-				"epcc_pricebook":                       dataSourceEpccPricebook(),
-				"epcc_product":                         dataSourceEpccProduct(),
-				"epcc_product_price":                   dataSourceEpccProductPrice(),
-				"epcc_promotion":                       dataSourceEpccPromotion(),
-				"epcc_realm":                           dataSourceEpccRealm(),
-				"epcc_profile":                         dataSourceEpccProfile(),
-				"epcc_user_authentication_info":        dataSourceEpccUserAuthenticationInfo(),
-				"epcc_account_authentication_settings": dataSourceAccountAuthenticationSettings(),
-				"epcc_customer_authentication_settings":       dataSourceCustomerAuthenticationSettings(),
+				"epcc_account":                          dataSourceEpccAccount(),
+				"epcc_catalog":                          dataSourceEpccCatalog(),
+				"epcc_currency":                         dataSourceEpccCurrency(),
+				"epcc_customer":                         dataSourceEpccCustomer(),
+				"epcc_entry":                            dataSourceEpccEntry(),
+				"epcc_field":                            dataSourceEpccField(),
+				"epcc_file":                             dataSourceEpccFile(),
+				"epcc_flow":                             dataSourceEpccFlow(),
+				"epcc_hierarchy":                        dataSourceEpccHierarchy(),
+				"epcc_integration":                      IntegrationDataSourceProvider{}.DataSource(),
+				"epcc_node":                             dataSourceEpccNode(),
+				"epcc_node_product":                     dataSourceEpccNodeProduct(),
+				"epcc_payment_gateway":                  PaymentGatewayDataSourceProvider{}.DataSource(),
+				"epcc_pricebook":                        dataSourceEpccPricebook(),
+				"epcc_product":                          dataSourceEpccProduct(),
+				"epcc_product_price":                    dataSourceEpccProductPrice(),
+				"epcc_promotion":                        dataSourceEpccPromotion(),
+				"epcc_realm":                            dataSourceEpccRealm(),
+				"epcc_profile":                          dataSourceEpccProfile(),
+				"epcc_user_authentication_info":         dataSourceEpccUserAuthenticationInfo(),
+				"epcc_account_authentication_settings":  dataSourceAccountAuthenticationSettings(),
+				"epcc_customer_authentication_settings": dataSourceCustomerAuthenticationSettings(),
 			},
 
 			ResourcesMap: map[string]*schema.Resource{
@@ -146,7 +146,27 @@ func configure(version string, p *schema.Provider) func(ctx context.Context, d *
 		var diags diag.Diagnostics
 
 		epccClientId := d.Get("client_id").(string)
+
+		if epccClientId == "" {
+			diags = append(diags, diag.Diagnostic{
+				Severity: diag.Error,
+				Summary:  "Unable to create EPCC Client",
+				Detail:   "To resolve this, ensure that you have properly set `client_id` in the provider configuration or the `EPCC_CLIENT_ID` environment variable.",
+			})
+			return nil, diags
+		}
+
 		epccClientSecret := d.Get("client_secret").(string)
+
+		if epccClientSecret == "" {
+			diags = append(diags, diag.Diagnostic{
+				Severity: diag.Error,
+				Summary:  "Unable to create EPCC Client",
+				Detail:   "To resolve this, ensure that you  have properly set `client_secret` in the provider configuration or set the `EPCC_CLIENT_SECRET` environment variable.",
+			})
+			return nil, diags
+		}
+
 		epccApiBaseUrl := d.Get("api_base_url").(string)
 		epccBetaFeatures := d.Get("beta_features").(string)
 


### PR DESCRIPTION
Issue: https://github.com/elasticpath/terraform-provider-epcc/issues/105

Move the validation of `EPCC_CLIENT_ID` and `EPCC_CLIENT_SECRET` to provider.go to set the error using the `diags` object and exit gracefully using the provided framework.